### PR TITLE
Week1_SunghunKim

### DIFF
--- a/Programmers_42889.swift
+++ b/Programmers_42889.swift
@@ -1,0 +1,24 @@
+func solution(_ N: Int, _ stages: [Int]) -> [Int] {
+    var stageInfo: [(stage: Int, failureRate: Double)] = []
+    var remainPlayer = stages.count
+    var stageCounts = Array(repeating: 0, count: N+2)
+    for stage in stages {
+        stageCounts[stage] += 1
+    }
+
+    for i in (1...N) {
+        let failed = stageCounts[i]
+        let failureRate: Double = remainPlayer == 0 ? 0.0 : Double(failed) / Double(remainPlayer)
+        stageInfo.append((i, failureRate))
+        remainPlayer -= failed
+    }
+
+    let result: [Int] = stageInfo.sorted {
+        if $0.failureRate == $1.failureRate {
+            $0.stage < $1.stage
+        }
+        return $0.failureRate > $1.failureRate
+    }.map { $0.stage }
+
+    return result
+}


### PR DESCRIPTION
## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42889

## ✔️ 소요된 시간
45분

## ✨ 수도 코드

> ### 문제요약
> - 총 `N`개의 스테이지가 존재하며,
> - `stages`배열은 플레이어가 현재 도전중인 스테이지 번호를 나타냅니다.
>   - 예: `N = 5, stages = [2, 1, 2, 6, 2, 4, 3, 3]`
>     - 5개의 스테이지가 존재하고, 8명의 플레이어가 존재하며,
>     - 2는 2스테이지에 도전중, 6은 모든 스테이지를 클리어했음을 의미합니다. (N+1)
>  - 목표는 `N`과 `stages`를 가지고 **실패율**을 리턴하면 됩니다.
>    - 실패율 = (현재 스테이지에 도달했지만 클리어하지 못한 인원 수) / (해당 스테이지에 도달한 전체 인원 수)

### 1차 설계
의도: `i`를 1부터 N까지 순회하면서 `i`스테이지 실패율을 정의하고, 정렬하여 스테이지 순서를 리턴하자
```swift
// 실패율
for i in (1...N) {
    // 분자 == i스테이지를 실패한 플레이어의 수 == stages에서 i의 개수
    // 분모 == 남아있는 플레이어의 수 == stages.count에서 분자를 누적하여 뺄셈
    // 실패율 == 분자 / 분모
    // 정렬되기 전 배열에 i와 실패율을 append하는 로직
}

// return
정렬하여 스테이지를 배열로 만들어서 리턴
```

### 2차 설계
```swift
// 선언부
var stageInfo: [(스테이지, 실패율)]  // 실패율에 맞게 정렬하여 스테이지를 리턴해야하므로 튜플 사용
var remainPlayer = stage.count  // 분모(남아있는 플레이어 수)가 누적해서 빼지므로 for문 밖에 선언

// 실패율
for i in (1...N) {
    var failed = stages에서 i의 개수  // 분자
    let failureRate = Double(failed) / Double(remainPlayer)  // 분모 / 분자
    stageInfo.append((i, failureRate))  // append 로직
    remainPlayer -= failed  // 분모(남아있는 플레이어 수) 업데이트
}

// return
stageInfo.sorted {
    // 실패율이 같으면 낮은 스테이지가 앞으로
    // 실패율이 높으면 스테이지를 앞으로
}
.map { ~~ }  // 배열로 만듦

```

### 구현
```swift
func solution(_ N: Int, _ stages: [Int]) -> [Int] {
    var stageInfo: [(stage: Int, failureRate: Double)] = []
    var remainPlayer = stages.count
    for i in (1...N) {
        var failed: Int = stages.filter { $0 == i }.count
        let failureRate: Double = remainPlayer == 0 ? 0.0 : Double(failed) / Double(remainPlayer)
        stageInfo.append((i, failureRate))
        remainPlayer -= failed
    }

    let result: [Int] = stageInfo.sorted {
        if $0.failureRate == $1.failureRate {
            $0.stage < $1.stage
        }
        return $0.failureRate > $1.failureRate
    }
    .map { $0.stage }

    return result
}
```

### 문제점

<img width="929" alt="스크린샷 2025-05-12 23 20 35" src="https://github.com/user-attachments/assets/1ebfa51f-2056-4367-afc1-c96b3f92aa30" />


```swift
for i in (1...N) {
        var failed: Int = stages.filter { $0 == i }.count  // 분자
```
`filter`의 시간복잡도를 놓쳐서 시간초과가 발생했습니다.
`filter`의 시간복잡는 O(stages.count) 만큼 가져서
코드의 총 시간복잡도가 O(N * stages.count)가 되므로 시간 초과가 발생할 수 밖에 없었습니다.

### 문제해결
```swift
    var stageCounts = Array(repeating: 0, count: N+2)
    for stage in stages {
        stageCounts[stage] += 1
    }

    for i in (1...N) {
        let failed = stageCounts[i]  // 분자
```
분자를 정의할 때 for문 안에서 `filter`를 사용하여 시간복잡도가 커지는 문제가 있었는데,
`stages`를 한 번만 순회하여 스테이지별 인원 수를 미리 카운팅하면 시간복잡도는 O(N + stages.count)가 되므로 이와 같이 수정했습니다.

## 📚 새롭게 알게된 내용
return 부분에서 고차함수를 사용했는데, 사용이 익숙하지 않아서 옛날에 사용했던 코드를 자꾸 찾아보게 되네요...