### PR TITLE
Week3_ChaeeunLee

### DIFF
--- a/ioo5959/투포인터/14921.py
+++ b/ioo5959/투포인터/14921.py
@@ -1,0 +1,38 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+lis = list(map(int, input().split()))
+
+# 방법 1. 순차적으로 다 계산해보기
+# mix_lis = []
+# close = 0
+# for i in range(n):
+#     for j in range(i+1, n):
+#         mix = lis[i] + lis[j]
+#         if i == 0 and j == 1:
+#             close = abs(mix)
+#         close = min(close, abs(mix))
+#         mix_lis.append(mix)
+
+left = 0
+right = n - 1
+min_mix = abs(lis[left] + lis[right])
+mix_lis = []
+while left < right:
+    mix = lis[left] + lis[right]
+    min_mix = min(min_mix, abs(mix))
+    mix_lis.append(mix)
+    if mix < 0:
+        left += 1
+    elif mix > 0:
+        right -= 1
+    else:
+        min_mix = 0
+        break
+
+result = 0
+for mix in mix_lis:
+    if abs(mix) == min_mix:
+        result = mix
+print(result)

--- a/ioo5959/투포인터/2531.py
+++ b/ioo5959/투포인터/2531.py
@@ -1,0 +1,42 @@
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+n, d, k, c = map(int, input().split())
+lis = [int(input()) for _ in range(n)]
+
+# 방법1 슬라이싱 -> 슬라이싱이 원형으로 진행되지 않아 right가 n을 넘어가면 k개로 슬라이싱이 안 됨
+# left, right = 0,k
+# max_value = 0
+# for _ in range(n):
+#     customer = lis[left:right]
+#     if len(customer) == len(set(customer)):
+#         if c in customer:
+#             max_value = k+1
+#         else:
+#             max_value = k
+#     left += 1
+#     if right < n:
+#         right += 1
+#     elif right == n:
+#         right = -1
+#     else:
+#         right -= 1
+
+window = deque()
+for i in range(k-1):
+    window.append(lis[i])
+
+max_value = 0
+for i in range(n):
+    window.append(lis[(i + k - 1) % n])
+
+    susi_kind = set(window)
+    if c not in susi_kind:
+        max_value = max(max_value, len(susi_kind) + 1)
+    else:
+        max_value = max(max_value, len(susi_kind))
+
+    window.popleft()
+
+print(max_value)


### PR DESCRIPTION
# 1. 회전초밥

## 🔗 문제 링크
https://www.acmicpc.net/problem/2531

## ✔️ 소요된 시간
4시간🥲

## ✨ 수도 코드
접근 1. 슬라이싱 사용
접근 2. deque 사용
```
큐에 첫 번째 초밥부터 (접시 수 -1) 만큼 저장
for n(벨트 위 초밥의 수)번 반복
  큐에 다음 초밥을 삽입
  중복되는 종류를 제외한 초밥의 종류에서
  쿠폰 초밥이 없으면 1을 더해 최댓값 비교 후 저장
  가장 앞에 있는 초밥 삭제
```
참고 코드 : https://pleasestudy-alswldi.tistory.com/149

## 📚 새롭게 알게된 내용
- deque() 생성 및 사용방법
```python
from collections import deque

queue = deque()
```

- 리스트 중복 검사
```python
lis == set(lis)
```
- 원형 탐색
```python
for i in range(n):
  lis.append(lis [(i + k) % n])
```
- 한 칸씩 이동하며 슬라이싱 해야 하는 경우, 슬라이싱 없이 삽입/삭제만으로 구현 가능


# 2. 용액 합치기
## 🔗 문제 링크
https://www.acmicpc.net/problem/14921

## ✔️ 소요된 시간
2시간

## ✨ 수도 코드
접근 1. 순차적으로 다 계산해보기

-> 시간 초과🙀

접근 2. 투 포인터

데이터들은 정렬된 상태로 입력됨
0과 가까운 수를 구하는 것이므로 
합이 마이너스이면 차이를 좁히기 위해 왼쪽을 +1칸 이동
합이 양수이면 오른쪽을 -1칸 이동

```
입력 = 리스트로 저장
left = 첫 번째 요소
right = 마지막 요소
최솟값 = (첫 번째 요소 + 마지막 요소)의 절댓값으로 초기화
mix_lis = 마지막에 값을 출력하기 위한 리스트

while left < right
  (list[left] + list[right])의 절댓값과 비교하여 최소값을 갱신
  mix_lis에 list[left] + list[right]값을 추가
  합이 0보다 작으면
    left += 1
  합이 0보다 크면
    right -= 1
  합이 0이면
    0을 저장하고 
    break

반복문을 사용해서 합의 절대값들의 최솟값과 mix_lis에 저장된 값의 절대값이 동일한 결과를 출력

```
참고 코드 : https://baby-ohgu.tistory.com/21

## 📚 새롭게 알게된 내용
- 시간 초과를 조심하기 위해 코드를 효율적으로 짤 수 있도록 노력하자..
- 0과 가까운 수를 구하기 위해서는 절대값이 가장 작은 수를 이용
- 문제에서 정렬된 상태로 입력된다면 그 이유가 무엇일지 생각해보기!