### PR TITLE
Week3_MinwooJe

### DIFF
--- a/MinwooJe/3주차_투포인터/1644_소수의_연속합.swift
+++ b/MinwooJe/3주차_투포인터/1644_소수의_연속합.swift
@@ -5,7 +5,7 @@ let primes = getPrimes(n)
 var result = 0
 
 // n이하의 소수가 존재하지 않는다면 (ex. n == 1) 실행하지 않음.
-if primes.isEmpty! {
+if !primes.isEmpty {
     var r = 0
     var sum = primes[0]
 

--- a/MinwooJe/3주차_투포인터/1644_소수의_연속합.swift
+++ b/MinwooJe/3주차_투포인터/1644_소수의_연속합.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+let n = Int(readLine()!)!
+let primes = getPrimes(n)
+var result = 0
+
+// n이하의 소수가 존재하지 않는다면 (ex. n == 1) 실행하지 않음.
+if primes.isEmpty! {
+    var r = 0
+    var sum = primes[0]
+
+    for l in 0..<primes.count {
+        while sum < n && r < primes.count - 1 {
+            r += 1
+            sum += primes[r]
+        }
+        
+        if sum == n {
+            result += 1
+        }
+        sum -= primes[l]
+    }
+}
+
+print(result)
+
+/// 에라토스테네스의 체를 이용해 n 이하의 모든 소수를 구함.
+func getPrimes(_ n: Int) -> [Int] {
+    guard n >= 2 else { return [] }
+    var isPrime = Array(repeating: true, count: n + 1)
+    let end = Int(sqrt(Double(n)))
+
+    for i in 2..<end + 1 {
+        guard isPrime[i] else { continue }
+        for j in stride(from: i + i, through: n, by: i) {
+            isPrime[j] = false
+        }
+    }
+    
+    return (2...n).filter { isPrime[$0] }
+}

--- a/MinwooJe/3주차_투포인터/20922_겹치는_건_싫어.swift
+++ b/MinwooJe/3주차_투포인터/20922_겹치는_건_싫어.swift
@@ -1,0 +1,21 @@
+let input = readLine()!.split(separator: " ").map { Int($0)! }
+let (n, k) = (input[0], input[1])
+let arr = readLine()!.split(separator: " ").map { Int($0)! }
+
+var result = 0
+var r = 0
+var countDict = [Int: Int]()
+
+countDict[arr[0]] = 1
+for l in 0..<n {
+    while r < n - 1 {
+        guard countDict[arr[r + 1], default: 0] + 1 <= k else { break }
+        r += 1
+        countDict[arr[r], default: 0] += 1
+    }
+    
+    result = max(result, r - l + 1)
+    countDict[arr[l]]! -= 1
+}
+
+print(result)


### PR DESCRIPTION
# 1. 백준 1644 - 소수의 연속합
## 🔗 문제 링크
[백준 1644번 소수의 연속합](https://www.acmicpc.net/problem/1644)

## ✔️ 소요된 시간
30분

## ✨ 수도 코드
에라토스테네스의 체를 사용한 후 일반적인 투 포인터 로직을 작성하면 됩니다!  
그런데 에라토스테네스의 체를 까먹어서.. 구현하는데 애먹었네요ㅠ

딱히 특별한 로직이 없어서 수도 코드는 생략하겠습니다!
```swift
import Foundation

let n = Int(readLine()!)!
let primes = getPrimes(n)
var result = 0

// n이하의 소수가 존재하지 않는다면 (ex. n == 1) 실행하지 않음.
if primes.isEmpty! {
    var r = 0
    var sum = primes[0]

    for l in 0..<primes.count {
        while sum < n && r < primes.count - 1 {
            r += 1
            sum += primes[r]
        }
        
        if sum == n {
            result += 1
        }
        sum -= primes[l]
    }
}

print(result)

/// 에라토스테네스의 체를 이용해 n 이하의 모든 소수를 구함.
func getPrimes(_ n: Int) -> [Int] {
    guard n >= 2 else { return [] }
    var isPrime = Array(repeating: true, count: n + 1)
    let end = Int(sqrt(Double(n)))

    for i in 2..<end + 1 {
        guard isPrime[i] else { continue }
        for j in stride(from: i + i, through: n, by: i) {
            isPrime[j] = false
        }
    }
    
    return (2...n).filter { isPrime[$0] }
}
```

# 1. 백준 20922 - 겹치는 건 싫어
## 🔗 문제 링크
[백준 20922번 겹치는 건 싫어](https://www.acmicpc.net/problem/20922)

## ✔️ 소요된 시간
1시간

## ✨ 수도 코드
### 문제 해석
같은 원소가 k개 이상이면 안됩니다.  
따라서 딕셔너리를 이용해 각 원소가 몇 개 나왔는지 기록해야겠다고 생각했습니다.  
### 첫 시도
딕셔너리에 저장되는 정보는 다음과 같습니다. `countDict: [원소: 나온 횟수]`  

따라서 지금까지 새로운 원소를 확인할 때 마다 딕셔너리의 key를 갱신하려고 했습니다.  
따라서 `maxAppearNum`이라는 변수에 매번 새로운 원소 확인 시 가장 많이 나온 원소를 저장하려고 했습니다.  

이 변수를 통해 `r` 포인터를 증가시키는 while문의 조건을 판단하려고 했습니다.

그러나 딕셔너리도 갱신해야되고, `maxAppearNum`도 매번 갱신해야 됐습니다.  
또한 다음과 같은 경우 `maxAppearNum`의 갱신의 시간 복잡도가 많이 걸릴 것이라 생각했습니다.  

> `countDict == [1: 10, 2: 11, 3: 10]`일 때, `l` 포인터가 한 칸 옮겨져 수열의 범위에서 2가 제외됨.  
> 즉, `countDict == [1: 10, 2: 10, 3: 10]` 인 상황에서 `maxAppearNum`을 갱신하기 위해 딕셔너리 전체를 순회해야함.
> 최악의 경우 딕셔너리 갱신 시 200_000 회 실행되고, 이 로직은 매 루프마다 수행되어야 함.

### 두 번째 시도
첫 번째 방법은 쓸데없이 복잡했다는 것을 깨달았습니다...  
`r` 포인터 이동 시 `countDict`에서 value가 변하는 놈은 `arr[r + 1]`딱 하나입니다. 
그냥 요놈만 확인해주면 됩니다...

```swift
let input = readLine()!.split(separator: " ").map { Int($0)! }
let (n, k) = (input[0], input[1])
let arr = readLine()!.split(separator: " ").map { Int($0)! }

var result = 0
var r = 0
var countDict = [Int: Int]()

countDict[arr[0]] = 1
for l in 0..<n {
    while r < n - 1 {
        guard countDict[arr[r + 1], default: 0] + 1 <= k else { break }
        r += 1
        countDict[arr[r], default: 0] += 1
    }
    
    result = max(result, r - l + 1)
    countDict[arr[l]]! -= 1
}

print(result)
```

## 📚 새롭게 알게된 내용
투 포인터는 개념만 알고 문제를 거의 풀어보진 않았는데, 쉬운것 같기도 하면서.. 아닌 것 같애요... 
인덱스 처리 같은 구현의 디테일을 잘 챙겨봐야겠습니다!