### PR TITLE
Week4_Chaeeun-Lee

### DIFF
--- a/ioo5959/DP/1149.py
+++ b/ioo5959/DP/1149.py
@@ -1,0 +1,15 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+matrix = [list(map(int, input().split())) for _ in range(n)]
+
+dp = [[0] *3 for _ in range(n)] # 가능한 경우의 수를 저장할 dp
+dp[0] = matrix[0][:] # 첫 줄은 그대로 넣음
+
+for i in range(1, n):
+    dp[i][0] = matrix[i][0] + min(dp[i - 1][1], dp[i - 1][2])
+    dp[i][1] = matrix[i][1] + min(dp[i - 1][0], dp[i - 1][2])
+    dp[i][2] = matrix[i][2] + min(dp[i - 1][0], dp[i - 1][1])
+
+print(min(dp[n-1])) #마지막 경우들 중 최솟값 출력

--- a/ioo5959/DP/2748.py
+++ b/ioo5959/DP/2748.py
@@ -1,0 +1,14 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+lis = [0,1]
+def fibo(f1, f2, count):
+    if count >= n:
+        return
+    f3 = f1 + f2
+    lis.append(f3)
+    fibo(f2, f3, count+1)
+
+fibo(0,1, 0)
+print(lis[n])


### PR DESCRIPTION
## 피보나치 수 2
## 🔗 문제 링크
https://www.acmicpc.net/problem/2748

## ✔️ 소요된 시간
5분

## ✨ 수도 코드
- 재귀함수 사용
```python
lis = 피보나치 수열 저장
def fibo(첫 번째 수, 두 번째 수, 카운트 변수)
  카운트가 n보다 크면 종료
  f3 = 첫 번째 수 + 두 번째 수
  lis에 f3 추가
  fibo(두 번째 수, f3, 카운트+1)

피보나치 수열에서 n번째 수 출력
```
## 📚 새롭게 알게된 내용
- dp로 해결한 게 아님..
- top-down 방식 : 재귀적으로 호출하면서 결과 저장하며 내려감 (마지막 -> 처음)
```python
def fibo(n):
  if n <= 1:
    return x
  if dp[x] != -1:
    return dp[x]
  dp[x] = fibo(x-1) + fibo(x-2) #재귀적으로 내려감
  return dp[x]
```
- bottom-up 방식 : 작은 값부터 반복문으로 누적 계산 (처음 -> 마지막)
```python
if n >= 1:
  dp[1] = 1
for i in range(2, n+1):
  dp[i] = dp[i-1]+dp[i-2]  # 앞에 두 수 더해서 dp에 저장
```

## RGB거리
## 🔗 문제 링크
https://www.acmicpc.net/problem/1149

## ✔️ 소요된 시간
4시간🥲

## ✨ 수도 코드
- 방법 1. 그리디 방식 : 한 칸 앞만 보고 앞에서 선택한 인덱스를 제외하고 최솟값 선택 -> 이전 선택만 고려해 다음 색을 선택하기 때문에 올바르지 않은 코드
```python
result = 0
idx = 0
for i in range(n):
    lis = matrix[i] # 한 집에서 선택할 수 있는 색 3가지
    if i == 0: # 첫번째 집인 경우 세 가지 색 중 가장 최솟값 선택
        first_min = min(lis)
        print(first_min)
        result += first_min
        for j in range(0,3):
            if lis[j] == first_min:
                idx = j
    else: # 두 번째 집부터 앞에서 선택한 색을 제외한 나머지 두 색 중 최솟값 선택
        min_house = min([v for i, v in enumerate(lis) if i != idx])
        print(min_house)
        result += min_house
        for j in range(0,3):
            if lis[j] == min_house:
                idx = j

print(result)
```

- 방법 2. dp를 사용해 나올 수 있는 경우를 모두 저장 : 현재 한 가지 색을 선택한 경우, 앞에서 나올 수 있는 모든 경우를 비교해 최솟값을 갱신해 저장. -> 총 3가지 경우가 나옴
```python
dp = 가능한 경우의 수를 저장할 이차원 리스트 (누적합)
dp[0] = 첫 번째 집의 비용을 그대로 저장
for 1 ~ n
  dp[i][0] = 현재 집의 빨강색 칠하는 비용 + 이전 dp의 초록, 파랑 중 최솟값
  dp[i][0] = 현재 집의 초록색 칠하는 비용 + 이전 dp의 빨강, 파랑 중 최솟값
  dp[i][0] = 현재 집의 파랑색 칠하는 비용 + 이전 dp의 빨강, 초록 중 최솟값
마지막 dp중 (3가지) 최소값 출력
```

참고 코드 : https://openmynotepad.tistory.com/8
## 📚 새롭게 알게된 내용
- dp 넘 어려움,,,
- 문제를 보고 dp로 해결하는 방법이 바로 나오지 않는다 -> 반복 연습 필요~